### PR TITLE
Link to symlink release RPM, not latest

### DIFF
--- a/softwarecollections/scls/templates/scls/softwarecollection_detail.html
+++ b/softwarecollections/scls/templates/scls/softwarecollection_detail.html
@@ -145,7 +145,7 @@
             <td>{{ repo.arch }}</td>
             {% if scl.last_synced %}
                 <td>
-                    <a href="{% url "scls:download" repo.slug %}{{ repo.rpmfile }}" title="{{ repo.rpmfile }}">RPM</a>
+                    <a href="{% url "scls:download" repo.slug %}{{ repo.rpmfile_symlink }}" title="{{ repo.rpmfile_symlink }}">RPM</a>
                     {{ repo.download_count }}x
                 </td>
                 <td><a href="{{ repo.get_repo_url }}" target="_blank" title="browse repo content">browse</a></td>


### PR DESCRIPTION
Follow-up to 999f2e7a, as the web UI still links to the versioned URL.
