### PR TITLE
Make sure pagination persists search options

### DIFF
--- a/softwarecollections/scls/templates/scls/pagination.html
+++ b/softwarecollections/scls/templates/scls/pagination.html
@@ -6,7 +6,7 @@
                 {% endif %}
 
                 {% for page in collections.paginator.page_range %}
-                    <li {% if forloop.counter == collections.number %} class="active" {% endif %} ><a href="?page={{page}}">{{page}}</a></li>
+                    <li {% if forloop.counter == collections.number %} class="active" {% endif %} ><a href="?{% for key,value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{page}}">{{page}}</a></li>
                 {% endfor %}
 
                 {% if collections.has_next %}


### PR DESCRIPTION
Currrently, if you apply a search filter and then click on one of the page numbers, the search filter is lost. It is not if you click the next or previous arrows. This patch makes sure that the search filter options is maintained when you click on a page number.
