### PR TITLE
Make makesuperuser command compatible with Django 1.11

### DIFF
--- a/softwarecollections/management/commands/makesuperuser.py
+++ b/softwarecollections/management/commands/makesuperuser.py
@@ -7,12 +7,16 @@ from django.db import DEFAULT_DB_ALIAS
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--database', action='store', dest='database',
-            default=DEFAULT_DB_ALIAS, help='Specifies the database to use. Default is "default".'),
-    )
-    args = '[ <username> ]'
-    help = 'Used to make user a superuser.'
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--database',
+            action='store',
+            dest='database',
+            default=DEFAULT_DB_ALIAS,
+            help='Specifies the database to use. Default is "default".',
+        )
+        parser.add_argument('username', nargs='?')
+        parser.help = 'Used to make user a superuser.'
 
     requires_system_checks = False
 


### PR DESCRIPTION
[Since Django 1.8](https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#django.core.management.BaseCommand.option_list), `BaseCommand.option_list` attribute is deprecated, and in Django 1.11 (Fedora 27), it is removed entirely.

This PR changes the argument registration of that command to be compatible with Django 1.11.