### PR TITLE
Add khardix/jstanek as admin

### DIFF
--- a/softwarecollections/localsettings-production.py
+++ b/softwarecollections/localsettings-production.py
@@ -36,6 +36,7 @@ ALLOWED_HOSTS = ['www.softwarecollections.org']
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-MANAGERS
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-SERVER_EMAIL
 ADMINS = (
+    ('Jan Staněk',     'jstanek@redhat.com'),
     ('Miroslav Suchý', 'msuchy@redhat.com'),
     ('Adam Samalik',   'asamalik@redhat.com'),
 )

--- a/softwarecollections/settings.py
+++ b/softwarecollections/settings.py
@@ -90,7 +90,10 @@ LOGGING = {
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler',
-        }
+        },
+        'null': {
+            'class': 'logging.NullHandler',
+        },
     },
     'loggers': {
         '': {
@@ -106,6 +109,10 @@ LOGGING = {
         'django.db.backends': {
             'level': DBDEBUG and 'DEBUG' or 'INFO',
             'propagate': True,
+        },
+        'django.security.DisallowedHost': {
+            'handlers': [] if DEBUG else ['null'],
+            'propagate': False,
         },
     }
 }


### PR DESCRIPTION
First step in properly taking over the codebase as primary maintainer -- adding myself into the `ADMINS` setting.

The other change should filter out error emails regarding attempts to access the site with disallowed hostname.